### PR TITLE
Fix global scope issue during build

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -36,10 +36,12 @@ module.exports = {
         // Also note: For mdx to work in NetlifyCMS, global scope passed in here
         // also be passed into `cms.js`, under the `scope` key.
         //
-        // globalScope: `
-        //   import * as Components from 'rebass'
-        //   export { Components }
-        //`
+        globalScope: `
+          import { UIComponents } from 'Theme'
+          export default {
+            ...UIComponents
+          }
+        `,
 
         // mdPlugins: [],
         // gatsbyRemarkPlugins: [{}],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -100,6 +100,7 @@ exports.onCreateWebpackConfig = ({ actions }) => {
       // }),
     ],
     resolve: {
+      // Enable absolute import paths
       modules: [path.resolve(__dirname, "src"), "node_modules"],
     },
   })

--- a/src/Theme.jsx
+++ b/src/Theme.jsx
@@ -6,6 +6,7 @@
 
 import React from "react"
 import styled, { ThemeProvider } from "styled-components"
+import { Button } from "rebass"
 
 export const theme = {
   // TODO: https://rebassjs.org/theming
@@ -22,6 +23,10 @@ const P = styled.div`
 export const LayoutComponents = {
   h1: H1,
   p: P,
+}
+
+export const UIComponents = {
+  Button: props => <Button {...props}>{props.children}</Button>,
 }
 
 export const Theme = ({ children }) => (

--- a/src/cms/cms.jsx
+++ b/src/cms/cms.jsx
@@ -1,8 +1,7 @@
-import { Button } from "rebass"
 import { MdxControl, MdxPreview } from "netlify-cms-widget-mdx"
 import React, { Component } from "react"
 import { StyleSheetManager } from "styled-components"
-import { Theme, LayoutComponents } from "../Theme"
+import { Theme, LayoutComponents, UIComponents } from "../Theme"
 import { FileSystemBackend } from "netlify-cms-backend-fs"
 import CMS, { init } from "netlify-cms"
 
@@ -48,9 +47,8 @@ const PreviewWindow = props => {
     // This key represents html elements used in markdown; h1, p, etc
     components: LayoutComponents,
     // Pass components used in the editor (and shared throughout mdx) here:
-    scope: {
-      Button: props => <Button {...props}>{props.children}</Button>,
-    },
+    scope: UIComponents,
+
     mdPlugins: [],
   }
 


### PR DESCRIPTION
Needed to pass the global component scope into `globalScope` in config: 

<img width="392" alt="screen shot 2019-01-26 at 12 06 51 pm" src="https://user-images.githubusercontent.com/236943/51792215-f86e4a80-2162-11e9-95dd-163482a5c206.png">

<img width="1157" alt="screen shot 2019-01-26 at 12 07 21 pm" src="https://user-images.githubusercontent.com/236943/51792217-fc01d180-2162-11e9-9cb6-63d1b4f23ac6.png">
