### PR TITLE
fix(gatsby-config.js): fix build errors

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -68,5 +68,7 @@ module.exports = {
     "gatsby-plugin-catch-links",
     "gatsby-plugin-styled-components",
     "gatsby-plugin-typescript",
+    "gatsby-transformer-sharp",
+    "gatsby-plugin-sharp",
   ],
 }


### PR DESCRIPTION
Fix build errors due to missing sharp plugins in config file.