### PR TITLE
fix(pages/index.tsx): disambiguate query name

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,7 @@ export default function Home() {
   return (
     <StaticQuery
       query={graphql`
-        query PagesQuery {
+        query AllPagesQuery {
           allMdx {
             edges {
               node {


### PR DESCRIPTION
Not sure if this is causing issues for anyone else, however gatsby didn't like the name `PagesQuery` for some reason. Perhaps because it's a substring of `CreatePagesQuery`? Either way I was getting the following error and this disambiguation fixed it.

```
 ERROR #85901  GRAPHQL

There was an error in your GraphQL query:

Error: RelayParser: Encountered duplicate defintitions for one or more documents: each document must have a unique name. Duplicated documents:
- PagesQuery

failed extract queries from components - 0.271s
```